### PR TITLE
Add lib: commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <jackson.version>2.12.7.1</jackson.version>
     <lombok.version>1.18.20</lombok.version>
     <pulsar.version>2.11.0.4</pulsar.version>
+    <commons-lang3.version>3.11</commons-lang3.version>
 
     <!-- test dependencies -->
     <testng.version>7.7.0</testng.version>
@@ -136,6 +137,11 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
         <version>${spotbugs-annotations.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
       </dependency>
       <!-- test dependencies -->
       <dependency>
@@ -224,6 +230,10 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
 
     <!-- test dependencies -->


### PR DESCRIPTION
### Motivation

`EventBridgeConfig.java` usage `commons-lang3`, and `commons-lang3` is dependencies by `pulsar-client-origin, but the scope of `pulsar-client-origin is `test`, it makes compile error.

[CI log of release `sn-pulsar:3.0.0.2`](https://github.com/streamnative/streamnative-ci/actions/runs/5168005384/jobs/9343126298?pr=3537)
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile (default-compile) on project pulsar-io-aws-eventbridge: Compilation failure
Error:  /home/runner/work/streamnative-ci/streamnative-ci/pulsar-io-aws-eventbridge/src/main/java/org/apache/pulsar/io/eventbridge/sink/EventBridgeConfig.java:[32,32] package org.apache.commons.lang3 does not exist
Error:  
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
/home/runner/work/_temp/ca0ec82b-ad42-4e5e-84d4-dcf5ec4d9d8c.sh: line 5: build.sh: command not found
```

### Modifications

add lib `commons-lang3`


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

